### PR TITLE
Load config from different files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,32 @@ Install the gem:
 
 #### Settings
 
-You must have a `PIVOTAL_API_KEY` environment variable set
-to your Pivotal api key, plus either a `.story_branch` file or
-`PIVOTAL_PROJECT_ID` environment variable set. Note, values in
-`.story_branch` will override environment variable settings.
+You can have your settings set either on a `.story_branch` file
+or in environment variables.
+
+The `.story_branch` files have priority over environment variables so if you set both,
+the configuration within `.story_branch` will be the one used.
+Also, the `.story_branch` file inside a project directory has priority over the global one.
+
+The settings will be loaded firstly from local config file, if not found then from global
+config file and ultimately from the environment variables. If none are found, an error
+will be thrown.
+
+This means that you can have a globally set api key and for each project using Pivotal Tracker
+have a local config inside the project folder.
+E.g.
+
+```
+$ cat ~/.story_branch
+api: your_API_key_that_you_get_from_pivotal_tracker
+
+$ cat ~/your_project_dir/.story_branch
+project: 123123
+```
+
+In case you prefer to use environment variables, you can set
+`PIVOTAL_API_KEY` to your pivotal tracker api key and set
+`PIVOTAL_PROJECT_ID` to your project id.
 
 #### .story_branch file
 

--- a/lib/story_branch.rb
+++ b/lib/story_branch.rb
@@ -103,7 +103,6 @@ module StoryBranch
     attr_accessor :p
 
     def initialize
-      @pivotal_info = YAML.load_file config_file if config_file
       @p = PivotalUtils.new
       @p.api_key = config_value 'api', 'PIVOTAL_API_KEY'
       @p.project_id = config_value 'project', 'PIVOTAL_PROJECT_ID'
@@ -202,12 +201,11 @@ module StoryBranch
       end
     end
 
-    def config_file
-      PIVOTAL_CONFIG_FILES.select{|conf| File.exists? conf}.first
-    end
-
     def config_value key, env
-      value = @pivotal_info[key] if @pivotal_info and @pivotal_info[key]
+      PIVOTAL_CONFIG_FILES.each do |config_file|
+        pivotal_info = YAML.load_file config_file
+        return pivotal_info[key] if pivotal_info[key]
+      end
       value ||= env_required env
       value
     end

--- a/lib/story_branch/version.rb
+++ b/lib/story_branch/version.rb
@@ -1,3 +1,3 @@
 module StoryBranch
-  VERSION = "0.2.9"
+  VERSION = "0.2.10"
 end

--- a/story_branch.gemspec
+++ b/story_branch.gemspec
@@ -7,7 +7,7 @@ require 'story_branch/version'
 Gem::Specification.new do |s|
   s.name        = 'story_branch'
   s.version     = StoryBranch::VERSION
-  s.date        = '2015-05-12'
+  s.date        = Date.today.to_s
   s.summary     = 'Story Branch - create git branches based on pivotal tracker stories'
   s.description = 'Simple gem that fetches the available stories in your pivotaltracker project and allows you to create a git branch with the name based on the selected story'
   s.authors     = ['Jason Milkins', 'Rui Baltazar', 'Dominic Wong', 'Ranhiru Cooray', 'Gabe Hollombe']


### PR DESCRIPTION
Allow one of the configs to be loaded from a global config file
(~/.story_branch)
while others from the project root config file
(.story_branch)