### PR TITLE
Remove byebug since it is not in dependency

### DIFF
--- a/lib/story_branch.rb
+++ b/lib/story_branch.rb
@@ -81,7 +81,6 @@
 #
 # Code:
 
-require 'byebug'
 require 'yaml'
 require 'blanket'
 require 'rb-readline'

--- a/lib/story_branch/version.rb
+++ b/lib/story_branch/version.rb
@@ -1,3 +1,3 @@
 module StoryBranch
-  VERSION = "0.2.11"
+  VERSION = "0.2.12"
 end


### PR DESCRIPTION
`byebug` dependency is defined here:
https://github.com/jasonm23/story_branch/blob/217b5fd6a695d02ca77dbe572e6ab823011121e7/story_branch.gemspec#L28

If we only use `gem install story_branch`, it won't be able to run.